### PR TITLE
Update batch commands for SCHISM and MPI

### DIFF
--- a/notebooks/sample_submit_hello_schism.ipynb
+++ b/notebooks/sample_submit_hello_schism.ipynb
@@ -65,7 +65,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "app_pkgs = [('schism', '580', 'opt/schism/5.8.0')]"
+    "app_pkgs = [('schism', '580_1', 'opt/schism/5.8.0')]"
    ]
   },
   {
@@ -250,34 +250,38 @@
     "    \"\"\"source /opt/intel/psxe_runtime/linux/bin/psxevars.sh intel64;\n",
     "source /opt/intel/psxe_runtime/linux/mpi/intel64/bin/mpivars.sh;\n",
     "export LD_LIBRARY_PATH=/opt/intel/psxe_runtime_2020.2.14/linux/compiler/lib/intel64_lin:$LD_LIBRARY_PATH;\n",
-    "export HDF5_DIR=${AZ_BATCH_APP_PACKAGE_schism_580}/opt/hdf5/1.12.0; \n",
-    "export NETCDF_C_DIR=${AZ_BATCH_APP_PACKAGE_schism_580}/opt/netcdf-c/4.7.4;\n",
-    "export NETCDF_FORTRAN_DIR=${AZ_BATCH_APP_PACKAGE_schism_580}/opt/netcdf-fortran/4.5.3;\n",
-    "export SZIP_DIR=${AZ_BATCH_APP_PACKAGE_schism_580}/opt/szip/2.1.1;\n",
-    "export PATH=${SZIP_DIR}/bin:${HDF5_DIR}/bin:${NETCDF_C_DIR}/bin:${NETCDF_FORTRAN_DIR}/bin:${AZ_BATCH_APP_PACKAGE_schism_580}/opt/schism/5.8.0/bin:$PATH;\n",
+    "export HDF5_DIR=${AZ_BATCH_APP_PACKAGE_schism_580_1}/opt/hdf5/1.10.8; \n",
+    "export NETCDF_C_DIR=${AZ_BATCH_APP_PACKAGE_schism_580_1}/opt/netcdf-c/4.8.1;\n",
+    "export NETCDF_FORTRAN_DIR=${AZ_BATCH_APP_PACKAGE_schism_580_1}/opt/netcdf-fortran/4.5.3;\n",
+    "export SZIP_DIR=${AZ_BATCH_APP_PACKAGE_schism_580_1}/opt/szip/2.1.1;\n",
+    "export PATH=${SZIP_DIR}/bin:${HDF5_DIR}/bin:${NETCDF_C_DIR}/bin:${NETCDF_FORTRAN_DIR}/bin:${AZ_BATCH_APP_PACKAGE_schism_580_1}/opt/schism/5.8.0/bin:$PATH;\n",
     "export LD_LIBRARY_PATH=${SZIP_DIR}/lib:${HDF5_DIR}/lib:${NETCDF_C_DIR}/lib:${NETCDF_FORTRAN_DIR}/lib:$LD_LIBRARY_PATH;\n",
     "echo $AZ_BATCH_HOST_LIST;\n",
     "echo $PATH;\n",
     "echo $LD_LIBRARY_PATH;\n",
     "export FI_PROVIDER=mlx;\n",
-    "export I_MPI_FABRICS=shm:ofi;\n",
-    "export I_MPI_DEBUG=5;\n",
-    "export I_MPI_PIN_DOMAIN=numa;\n",
-    "cd ${AZ_BATCH_TASK_ID};\n",
-    "tar xvzf hello_schism-master.tar.gz;\n",
-    "cd hello_schism;\n",
-    "mkdir outputs;\n",
+    "# export I_MPI_FABRICS=shm:ofi;\n",
+    "# export I_MPI_DEBUG=5;\n",
+    "# export I_MPI_PIN_DOMAIN=numa;\n",
+    "cd ${AZ_BATCH_TASK_SHARED_DIR}/wd/hello_schism;\n",
     "\"\"\"+\n",
     "f\"\"\"export NUM_CORES={num_cores};\n",
     "export NUM_HOSTS={num_hosts};\n",
     "\"\"\"\n",
     "+\n",
-    "\"\"\"mpirun -n $NUM_CORES -ppn $NUM_HOSTS -hosts $AZ_BATCH_HOST_LIST ${AZ_BATCH_APP_PACKAGE_schism_580}/opt/schism/5.8.0/pschism_PREC_EVAP_GOTM_TVD-VL;\n",
+    "\"\"\"mpirun -wdir ${AZ_BATCH_TASK_SHARED_DIR}/wd/hello_schism -n $NUM_CORES -ppn $NUM_HOSTS -hosts $AZ_BATCH_HOST_LIST ${AZ_BATCH_APP_PACKAGE_schism_580_1}/opt/schism/5.8.0/pschism_PREC_EVAP_GOTM_TVD-VL_no_shared_dir;\n",
     "\"\"\",app_pkgs,ostype='linux')\n",
     "print(task_name)\n",
     "print(cmd_string)\n",
     "#mpirun -n $NUM_CORES -ppn $NUM_HOSTS -hosts $AZ_BATCH_HOST_LIST ${AZ_BATCH_APP_PACKAGE_schism_580}/opt/schism/5.8.0/pschism_PREC_EVAP_GOTM_TVD-VL;\n",
-    "#mpirun -n $NUM_CORES -ppn $NUM_HOSTS -hosts $AZ_BATCH_HOST_LIST IMB-MPI1 pingpong;"
+    "#mpirun -n $NUM_CORES -ppn $NUM_HOSTS -hosts $AZ_BATCH_HOST_LIST IMB-MPI1 pingpong;\n",
+    "\n",
+    "coordination_cmd = \"\"\"\n",
+    "echo Coord $(pwd);\n",
+    "tar xvzf ../${AZ_BATCH_TASK_ID}/hello_schism-master.tar.gz;\n",
+    "cd hello_schism;\n",
+    "mkdir outputs;\n",
+    "\"\"\""
    ]
   },
   {
@@ -337,9 +341,10 @@
    "outputs": [],
    "source": [
     "schism_task = client.create_task(task_name,cmd_string,\n",
-    "                                 resource_files=[input_file],\n",
     "                                 output_files=[std_out_files, output_dir],\n",
-    "                                 num_instances=num_hosts, coordination_cmdline='echo $AZ_BATCH_HOST_LIST')"
+    "                                 num_instances=num_hosts,\n",
+    "                                 coordination_cmdline=coordination_cmd,\n",
+    "                                 coordination_files=[input_file],)"
    ]
   },
   {


### PR DESCRIPTION
The commit splits the application commands into application and
coordination ones. The commit also uses a new SCHISM application,
named 580_1. It removed a shared file requirement for fatal.error
from the SCHISM binary, which prevent SCHISM from running without
a shared file system.